### PR TITLE
Fixed a variable name mismatch

### DIFF
--- a/source/fmod_gml/FMOD.yyp
+++ b/source/fmod_gml/FMOD.yyp
@@ -2,7 +2,7 @@
   "$GMProject":"v1",
   "%Name":"FMOD",
   "AudioGroups":[
-    {"$GMAudioGroup":"v1","%Name":"audiogroup_default","exportDir":"","name":"audiogroup_default","resourceType":"GMAudioGroup","resourceVersion":"2.0","targets":-1,},
+    {"$GMAudioGroup":"","%Name":"audiogroup_default","name":"audiogroup_default","resourceType":"GMAudioGroup","resourceVersion":"2.0","targets":-1,},
   ],
   "configs":{
     "children":[],
@@ -62,12 +62,9 @@
     {"$GMIncludedFile":"","%Name":"truck_idle_off_06.wav","CopyToMask":-1,"filePath":"datafiles/granular","name":"truck_idle_off_06.wav","resourceType":"GMIncludedFile","resourceVersion":"2.0",},
     {"$GMIncludedFile":"","%Name":"jaguar.wav","CopyToMask":-1,"filePath":"datafiles","name":"jaguar.wav","resourceType":"GMIncludedFile","resourceVersion":"2.0",},
     {"$GMIncludedFile":"","%Name":"master.bank","CopyToMask":-1,"filePath":"datafiles","name":"master.bank","resourceType":"GMIncludedFile","resourceVersion":"2.0",},
-    {"$GMIncludedFile":"","%Name":"Master.bank","CopyToMask":-1,"filePath":"datafiles","name":"Master.bank","resourceType":"GMIncludedFile","resourceVersion":"2.0",},
     {"$GMIncludedFile":"","%Name":"master.strings.bank","CopyToMask":-1,"filePath":"datafiles","name":"master.strings.bank","resourceType":"GMIncludedFile","resourceVersion":"2.0",},
-    {"$GMIncludedFile":"","%Name":"Master.strings.bank","CopyToMask":-1,"filePath":"datafiles","name":"Master.strings.bank","resourceType":"GMIncludedFile","resourceVersion":"2.0",},
     {"$GMIncludedFile":"","%Name":"Music.bank","CopyToMask":-1,"filePath":"datafiles","name":"Music.bank","resourceType":"GMIncludedFile","resourceVersion":"2.0",},
     {"$GMIncludedFile":"","%Name":"sfx.bank","CopyToMask":-1,"filePath":"datafiles","name":"sfx.bank","resourceType":"GMIncludedFile","resourceVersion":"2.0",},
-    {"$GMIncludedFile":"","%Name":"SFX.bank","CopyToMask":-1,"filePath":"datafiles","name":"SFX.bank","resourceType":"GMIncludedFile","resourceVersion":"2.0",},
     {"$GMIncludedFile":"","%Name":"singing.wav","CopyToMask":-1,"filePath":"datafiles","name":"singing.wav","resourceType":"GMIncludedFile","resourceVersion":"2.0",},
     {"$GMIncludedFile":"","%Name":"standrews.wav","CopyToMask":-1,"filePath":"datafiles","name":"standrews.wav","resourceType":"GMIncludedFile","resourceVersion":"2.0",},
     {"$GMIncludedFile":"","%Name":"Vehicles.bank","CopyToMask":-1,"filePath":"datafiles","name":"Vehicles.bank","resourceType":"GMIncludedFile","resourceVersion":"2.0",},

--- a/source/fmod_gml/scripts/Fmod_Functions/Fmod_Functions.gml
+++ b/source/fmod_gml/scripts/Fmod_Functions/Fmod_Functions.gml
@@ -2717,7 +2717,7 @@ function FmodStudioAdvancedSettings() constructor {
 	command_queue_size = 32768;
 	handle_initial_size = 8192 * 8;
 	studio_update_period = 20;
-	idle_sampledata_pool_size = 262144;
+	idle_sample_data_pool_size = 262144;
 	streaming_schedule_delay = 8192
 	encryption_key = pointer_null;
 }


### PR DESCRIPTION
This fixes the variable name mismatch in the `FmodStudioAdvancedSettings` constructor and `fmod_studio_system_set_advanced_settings` function. The `FmodStudioAdvancedSettings` constructor has `idle_sampledata_pool_size`, and `fmod_studio_system_set_advanced_settings` uses `idle_sample_data_pool_size`. This adds an underscore to the property in the constructor.